### PR TITLE
Make init job annotations optional

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -18,9 +18,9 @@ metadata:
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
+  {{- with .Values.init.jobAnnotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -361,6 +361,11 @@ init:
   labels:
     app.kubernetes.io/component: init
 
+  # Annotations to add to the init job
+  jobAnnotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+
   # Additional annotations to apply to the Pod of this Job.
   annotations: {}
 


### PR DESCRIPTION
Some kubernetes executors like argo will not deploy this chart correctly with these annotations. I've found that these annotations need to be removed and replaced with:

```
argocd.argoproj.io/hook: Sync
argocd.argoproj.io/hook-delete-policy: HookFailed
helm.sh/hook: null
helm.sh/hook-delete-policy: null
```